### PR TITLE
Make the MIME fields for attachments accessible from the plugin

### DIFF
--- a/lib/Dancer/Plugin/Email.pm
+++ b/lib/Dancer/Plugin/Email.pm
@@ -31,25 +31,25 @@ register email => sub {
     if ($attach) {
         my @attachments = ref($attach) eq 'ARRAY' ? @$attach : $attach;
         for my $attachment (@attachments) {
-	    my %mime;
-	    # if it's an hash, we pass it verbatim to the
-	    # MIME::Entity builder
-	    if (ref($attachment) eq 'HASH') {
-		%mime = %$attachment;
-		unless ($mime{Path}) {
-		    warning "No Path provided for this attachment!";
-		    next;
-		};
-		$mime{Encoding} ||= 'base64';
-		$mime{Type} ||= File::Type->mime_type($mime{Path}),
-	    } else {
-		%mime = (
-			 Path     => $attachment,
-			 Type     => File::Type->mime_type($attachment),
-			 Encoding => 'base64',
-			);
-	    }
-	    # debug to_dumper(\%mime);
+            my %mime;
+            # if it's an hash, we pass it verbatim to the
+            # MIME::Entity builder
+            if (ref($attachment) eq 'HASH') {
+                %mime = %$attachment;
+                unless ($mime{Path}) {
+                    warning "No Path provided for this attachment!";
+                    next;
+                };
+                $mime{Encoding} ||= 'base64';
+                $mime{Type} ||= File::Type->mime_type($mime{Path}),
+            } else {
+                %mime = (
+                         Path     => $attachment,
+                         Type     => File::Type->mime_type($attachment),
+                         Encoding => 'base64',
+                        );
+            }
+            # debug to_dumper(\%mime);
             $email->attach(%mime);
         }
     }
@@ -143,14 +143,14 @@ so wrapping calls to C<email> with try/catch is recommended.
                 subject => 'allo',
                 body    => 'Dear Sue, ...<img src="cid:blabla">',
                 attach  => ['/path/to/attachment1',
-			    '/path/to/attachment2',
-			    {
-			     Path => "attachment3",
-			     # Path is required when passing a hashref
-			     # for other optional values, see Mime::Entity
-			     Id => "blabla",
-			    }
-			   ],
+                            '/path/to/attachment2',
+                            {
+                             Path => "attachment3",
+                             # Path is required when passing a hashref
+                             # for other optional values, see Mime::Entity
+                             Id => "blabla",
+                            }
+                           ],
                 type    => 'html', # can be 'html' or 'plain'
                 # Optional extra headers
                 headers => {


### PR DESCRIPTION
This patch doesn't break retrocompatibility. When passing an hashref
to the attachment, pass the hash to MIME::Entity, complaining if Path
is missing.

If a string is passed, the original routine is used.

The example in the documentation has been changed to show a possible
use (embedding CID images in HTML mails).
