### PR TITLE
Prevent subroutine prototype mismatch between Dancer's load and Module::Load

### DIFF
--- a/lib/Dancer/Plugin/Email.pm
+++ b/lib/Dancer/Plugin/Email.pm
@@ -1,6 +1,6 @@
 package Dancer::Plugin::Email;
 
-use Dancer qw(:syntax !load);
+use Dancer qw(:syntax debug warning);
 use Dancer::Plugin;
 use Email::Sender::Simple 'sendmail';
 use Email::Date::Format 'email_date';


### PR DESCRIPTION
Without preventing Dancer's load subroutine form being exported it will conflict with Module::Load's load subroutine.  Giving warnings like:

Subroutine Dancer::Plugin::Email::load redefined at /usr/local/lib/perl5/site_perl/5.18.2/Module/Load.pm line 30.
Prototype mismatch: sub Dancer::Plugin::Email::load: none vs (*;@) at /usr/local/lib/perl5/site_perl/5.18.2/Module/Load.pm line 30.

This patch prevent's Dancer's load keyword from being exported.
